### PR TITLE
Modify handling of regions and partitions

### DIFF
--- a/AWSScout2/utils_cloudtrail.py
+++ b/AWSScout2/utils_cloudtrail.py
@@ -29,10 +29,10 @@ def tweak_cloudtrail_findings(aws_config):
             aws_config['services']['cloudtrail']['violations']['cloudtrail-no-logging']['flagged_items'] += 1
             aws_config['services']['cloudtrail']['violations']['cloudtrail-no-logging']['dashboard_name'] = 'Regions'
 
-def get_cloudtrail_info(credentials, service_config, selected_regions, with_gov, with_cn):
+def get_cloudtrail_info(credentials, service_config, selected_regions, partition_name):
     manage_dictionary(service_config, 'regions', {})
     printInfo('Fetching CloudTrail config...')
-    for region in build_region_list('cloudtrail', selected_regions, include_gov = with_gov, include_cn = with_cn):
+    for region in build_region_list('cloudtrail', selected_regions, partition_name):
         manage_dictionary(service_config['regions'], region, {})
         service_config['regions'][region]['name'] = region
     thread_work(service_config['regions'], get_region_trails, params = {'creds': credentials, 'cloudtrail_info': service_config})

--- a/AWSScout2/utils_ec2.py
+++ b/AWSScout2/utils_ec2.py
@@ -139,9 +139,9 @@ def list_network_attack_surface(ec2_info, attack_surface_attribute_name, ip_attr
 ##### EC2 fetch functions
 ########################################
 
-def get_ec2_info(credentials, service_config, selected_regions, with_gov, with_cn):
+def get_ec2_info(credentials, service_config, selected_regions, partition_name):
     # Prep regions
-    all_regions = build_region_list('ec2', selected_regions, include_gov = with_gov, include_cn = with_cn)
+    all_regions = build_region_list('ec2', selected_regions, partition_name)
     manage_dictionary(service_config, 'regions', {})
     for region in all_regions:
         manage_dictionary(service_config['regions'], region, {})

--- a/AWSScout2/utils_rds.py
+++ b/AWSScout2/utils_rds.py
@@ -10,10 +10,10 @@ from AWSScout2.utils import *
 ##### RDS functions
 ########################################
 
-def get_rds_info(credentials, service_config, selected_regions, with_gov, with_cn):
+def get_rds_info(credentials, service_config, selected_regions, partition_name):
     printInfo('Fetching RDS config...')
     manage_dictionary(service_config, 'regions', {})
-    for region in build_region_list('rds', selected_regions, include_gov = with_gov, include_cn = with_cn):
+    for region in build_region_list('rds', selected_regions, partition_name):
         manage_dictionary(service_config['regions'], region, {})
         service_config['regions'][region]['name'] = region
     thread_work(service_config['regions'], get_rds_region, params = {'creds': credentials, 'rds_info': service_config})

--- a/AWSScout2/utils_rds.py
+++ b/AWSScout2/utils_rds.py
@@ -72,7 +72,7 @@ def get_instances_info(rds_client, region_info):
         dbi_info = {}
         total = total + len(dbinstances)
         dbi_info['name'] = dbi.pop('DBInstanceIdentifier')
-        for key in [ 'InstanceCreateTime', 'Engine', 'DBInstanceStatus', 'AutoMinorVersionUpgrade', 'DBInstanceClass', 'MultiAZ', 'Endpoint', 'BackupRetentionPeriod', 'PubliclyAccessible', 'StorageEncrypted', 'VpcSecurityGroups', 'DBSecurityGroups', 'DBParameterGroups']:
-            # parameter_groups , security_groups, vpc_security_gropus
+        for key in [ 'InstanceCreateTime', 'Engine', 'DBInstanceStatus', 'AutoMinorVersionUpgrade', 'DBInstanceClass', 'MultiAZ', 'Endpoint', 'BackupRetentionPeriod', 'PubliclyAccessible', 'StorageEncrypted', 'VpcSecurityGroups', 'DBSecurityGroups', 'DBParameterGroups', 'EnhancedMonitoringResourceArn']:
+            # parameter_groups , security_groups, vpc_security_groups
             dbi_info[key] = dbi[key] if key in dbi else None
         region_info['vpcs'][vpc_id]['instances'][get_non_aws_id(dbi_info['name'])] = dbi_info

--- a/AWSScout2/utils_redshift.py
+++ b/AWSScout2/utils_redshift.py
@@ -13,10 +13,10 @@ from AWSScout2.utils import *
 #
 # Entry point
 #
-def get_redshift_info(credentials, service_config, selected_regions, with_gov, with_cn):
+def get_redshift_info(credentials, service_config, selected_regions, partition_name):
     printInfo('Fetching Redshift config...')
     manage_dictionary(service_config, 'regions', {}) 
-    regions = build_region_list('redshift', selected_regions, include_gov = with_gov, include_cn = with_cn)
+    regions = build_region_list('redshift', selected_regions, partition_name)
     for region in regions:
         manage_dictionary(service_config['regions'], region, {})
         manage_dictionary(service_config['regions'][region], 'vpcs', {})

--- a/AWSScout2/utils_s3.py
+++ b/AWSScout2/utils_s3.py
@@ -266,7 +266,7 @@ def get_s3_bucket_keys(s3_client, bucket_name, bucket, check_encryption, check_a
         update_status(key_count, bucket['keys_count'], 'keys')
 
 
-def get_s3_info(credentials, service_config, selected_regions, with_gov, with_cn, s3_params):
+def get_s3_info(credentials, service_config, selected_regions, partition_name, s3_params):
     # h4ck :: Create multiple clients here to avoid propagation of credentials. This is necessary because s3 is a global service that requires to access the API via the right region endpoints...
     s3_clients = {}
     if selected_regions != []:
@@ -275,7 +275,7 @@ def get_s3_info(credentials, service_config, selected_regions, with_gov, with_cn
             client_regions.append('us-east-1')
     else:
         client_regions = selected_regions
-    for region in build_region_list('s3', client_regions, include_gov = with_gov, include_cn = with_cn):
+    for region in build_region_list('s3', client_regions, partition_name):
         config = botocore.client.Config(signature_version = 's3v4')
         s3_clients[region] = connect_s3(credentials, region_name = region, config = config)
     s3_params['selected_regions'] = selected_regions

--- a/RulesGenerator.py
+++ b/RulesGenerator.py
@@ -96,7 +96,17 @@ def main(cmd_args):
                             prule['level'] = 'danger'
                         available_rules[key] = prule
                 if not parameterized_rule_found:
-                    printError('Error: the rule %s lacks parameters in the ruleset.' % rule_filename)
+                    # Save once with no parameters
+                    available_rules[rule_filename] = rule
+                    available_rules[rule_filename]['enabled'] = False
+                    if 'level' not in available_rules[rule_filename]:
+                        available_rules[rule_filename]['level'] = 'danger'
+                    available_rules[rule_filename]['filename'] = rule_filename
+                    args = []
+                    for a in rule['arg_names']:
+                        args.append({'arg_name': a, 'arg_value': ''})
+                    available_rules[rule_filename]['args'] = args
+                    printDebug('Saving rule without parameter value: %s' % rule_filename)
 
     ruleset = {}
     ruleset['name'] = cmd_args.ruleset_name

--- a/Scout2.py
+++ b/Scout2.py
@@ -104,8 +104,7 @@ def main(args):
                 method_args['service_config'] = aws_config['services'][service]
                 if service != 'iam':
                     method_args['selected_regions'] = args.regions
-                    method_args['with_gov'] = args.with_gov
-                    method_args['with_cn'] = args.with_cn
+                    method_args['partition_name'] = args.partition_name
                 if service == 's3':
                     method_args['s3_params'] = {}
                     method_args['s3_params']['check_encryption'] = args.check_s3_encryption
@@ -267,8 +266,7 @@ default_args = read_profile_default_args(parser.prog)
 add_sts_argument(parser, 'mfa-serial')
 add_sts_argument(parser, 'mfa-code')
 add_common_argument(parser, default_args, 'regions')
-add_common_argument(parser, default_args, 'with-gov')
-add_common_argument(parser, default_args, 'with-cn')
+add_common_argument(parser, default_args, 'partition-name')
 add_common_argument(parser, default_args, 'ip-ranges')
 add_common_argument(parser, default_args, 'ip-ranges-key-name')
 add_iam_argument(parser, default_args, 'csv-credentials')

--- a/html/partials/services.rds.regions.id.vpcs.id.instances.html
+++ b/html/partials/services.rds.regions.id.vpcs.id.instances.html
@@ -15,6 +15,9 @@
             <li class="list-group-item-text">Instance Class: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.DBInstanceClass"> {{DBInstanceClass}}<span></li>
             <li class="list-group-item-text">Created on: {{InstanceCreateTime}}</li>
             <li class="list-group-item-tex">Backup retention period in days: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.BackupRetentionPeriod">{{BackupRetentionPeriod}}</span>
+            <li class="list-group-item-tex">Enhanced Monitoring:
+              <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.EnhancedMonitoringResourceArn">{{#if EnhancedMonitoringResourceArn}} Enabled {{else}} Disabled {{/if}}</span>
+            </li>
           </ul>
           <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.pgsslcert" class="finding-hidden item-margin">
            <i class="glyphicon glyphicon-warning-sign"></i> SSL/TLS certificates on PostgreSQL instances created before August 8, 2014, cannot be verified.

--- a/html/partials/services.rds.regions.id.vpcs.id.instances.html
+++ b/html/partials/services.rds.regions.id.vpcs.id.instances.html
@@ -10,16 +10,16 @@
             <li class="list-group-item-text">Region: {{region}}</li>
             <li class="list-group-item-text">Engine: {{Engine}}</li>
             <li class="list-group-item-text">Status: {{make_title DBInstanceStatus}}</li>
-            <li class="list-group-item-text">Auto Minor Version Upgrade: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.AutoMinorVersionUpgrade">{{#if AutoMinorVersionUpgrade}} Enabled {{else}} Disabled {{/if}}</span></li>
-            <li class="list-group-item-text">Multi Availability Zones: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.MultiAZ">{{#if MultiAZ}} Enabled {{else}} Disabled {{/if}}</span></li>
-            <li class="list-group-item-text">Instance Class: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.DBInstanceClass"> {{DBInstanceClass}}<span></li>
+            <li class="list-group-item-text">Auto Minor Version Upgrade: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{@key}}.AutoMinorVersionUpgrade">{{#if AutoMinorVersionUpgrade}} Enabled {{else}} Disabled {{/if}}</span></li>
+            <li class="list-group-item-text">Multi Availability Zones: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{@key}}.MultiAZ">{{#if MultiAZ}} Enabled {{else}} Disabled {{/if}}</span></li>
+            <li class="list-group-item-text">Instance Class: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{@key}}.DBInstanceClass"> {{DBInstanceClass}}<span></li>
             <li class="list-group-item-text">Created on: {{InstanceCreateTime}}</li>
-            <li class="list-group-item-tex">Backup retention period in days: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.BackupRetentionPeriod">{{BackupRetentionPeriod}}</span>
+            <li class="list-group-item-tex">Backup retention period in days: <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{@key}}.BackupRetentionPeriod">{{BackupRetentionPeriod}}</span>
             <li class="list-group-item-tex">Enhanced Monitoring:
-              <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.EnhancedMonitoringResourceArn">{{#if EnhancedMonitoringResourceArn}} Enabled {{else}} Disabled {{/if}}</span>
+              <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{@key}}.EnhancedMonitoringResourceArn">{{#if EnhancedMonitoringResourceArn}} Enabled {{else}} Disabled {{/if}}</span>
             </li>
           </ul>
-          <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{name}}.pgsslcert" class="finding-hidden item-margin">
+          <span id="rds.regions.{{region}}.vpcs.{{vpc}}.instances.{{@key}}.pgsslcert" class="finding-hidden item-margin">
            <i class="glyphicon glyphicon-warning-sign"></i> SSL/TLS certificates on PostgreSQL instances created before August 8, 2014, cannot be verified.
           </span>
         </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil>=2.2
 netaddr>=0.7.11
-opinel>=1.2.0,<1.3.0
+opinel>=1.3.1,<1.4.0

--- a/rules/iam-password-policy-expiration-threshold.json
+++ b/rules/iam-password-policy-expiration-threshold.json
@@ -1,7 +1,9 @@
 {
-    "args": [ "Maximum password age" ],
+    "arg_names": [ "Maximum password age" ],
     "description": "Passwords expire after _ARG_0_ days",
     "path": "iam.password_policy",
+    "display_path": "iam.password_policy.MaxPasswordAge",
+    "id_suffix": "MaxPasswordAge",
     "dashboard_name": "Password policy",
     "conditions": [ "or",
         [ "iam.password_policy.ExpirePasswords", "false", "" ],


### PR DESCRIPTION
Update Scout2 to use latest opinel with up-to-date endpoints and new argument (partition name vs --with-gov and --with-cn)