### PR TITLE
All ports are open if all protocols allowed

### DIFF
--- a/rules/ec2-security-group-opens-all-ports-to-all.json
+++ b/rules/ec2-security-group-opens-all-ports-to-all.json
@@ -6,6 +6,9 @@
     "conditions": [ "and",
         [ "this", "equal", "0.0.0.0/0" ],
         [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id", "equal", "ingress" ],
-        [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id.ports.id", "equal", "0-65535" ]
+        [ "or",
+            [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id.ports.id", "equal", "0-65535" ],
+            [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id", "equal", "ALL" ]
+        ]
     ]
 }

--- a/rules/ec2-security-group-opens-all-ports.json
+++ b/rules/ec2-security-group-opens-all-ports.json
@@ -3,8 +3,10 @@
     "path": "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id.ports.id",
     "dashboard_name": "Rules",
     "conditions": [ "and",
-        [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id.ports.id", "containAtLeastOneOf", ["0-65535", "ALL"] ],
-        [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id", "containAtLeastOneOf", ["ALL", "UDP", "TCP"] ],
+        [ "or",
+            [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id.ports.id", "equal", "0-65535" ],
+            [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols.id", "equal", "ALL" ]
+        ],
         [ "ec2.regions.id.vpcs.id.security_groups.id.rules.id", "equal", "ingress" ],
         [ "ec2.regions.id.vpcs.id.security_groups.id.", "withKey", "used_by" ]
     ],


### PR DESCRIPTION
The current "All ports open" and "All ports open to all" rules don't match security groups I have seen which use the "All traffic" template. I have modified them to always match if the IP protocol is set to "ALL" since "if you specify [all protocols], or a protocol number other than tcp, udp, icmp, or 58 (ICMPv6), traffic on all ports is allowed, regardless of any ports you specify" (see http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html).