### PR TITLE
S3 config fetch bug

### DIFF
--- a/AWSScout2/services/s3.py
+++ b/AWSScout2/services/s3.py
@@ -38,7 +38,7 @@ class S3Config(BaseConfig):
         Parse a single S3 bucket TODO
         """
         bucket['name'] = bucket.pop('Name')
-        api_client = params['api_clients'][get_s3_list_region(params['api_clients'].keys()[0])]
+        api_client = params['api_clients'][get_s3_list_region(list(params['api_clients'].keys())[0])]
 
         bucket['CreationDate'] = str(bucket['CreationDate'])
         bucket['region'] = get_s3_bucket_location(api_client, bucket['name'])


### PR DESCRIPTION
Fixed
`"Fetching S3 config...
buckets
'dict_keys' object does not support indexing'dict_keys"`
The keys() function changed to return a dict instead of a list.
Tested with Python 3.5 and 3.6


