### PR TITLE
Fix S3 policy rules to work with AWS principals

### DIFF
--- a/AWSScout2/rules/data/findings/s3-bucket-world-policy-arg.json
+++ b/AWSScout2/rules/data/findings/s3-bucket-world-policy-arg.json
@@ -9,9 +9,15 @@
         [ "s3.buckets.id.", "withKey", "policy" ],
         [ "s3.buckets.id.policy.Statement.id.Effect", "equal", "Allow" ],
         [ "s3.buckets.id.policy.Statement.id.", "withoutKey", "Condition" ],
-        [ "s3.buckets.id.policy.Statement.id.Principal", "containAtLeastOneOf", [ "*" ] ],
         [ "s3.buckets.id.policy.Statement.id.", "containAction", "_ARG_1_" ],
-        [ "s3.buckets.id.policy.Statement.id.Action", "containNoneOf", [ "s3:*", "*" ] ]
+        [ "s3.buckets.id.policy.Statement.id.Action", "containNoneOf", [ "s3:*", "*" ] ],
+        [ "or",
+          [ "s3.buckets.id.policy.Statement.id.Principal", "containAtLeastOneOf", [ "*" ] ],
+          [ "and",
+            [ "s3.buckets.id.policy.Statement.id.Principal", "withKey", "AWS" ],
+            [ "s3.buckets.id.policy.Statement.id.Principal.AWS", "containAtLeastOneOf", [ "*" ] ]
+          ]
+        ]
     ],
     "keys": [
         "s3.buckets.id",

--- a/AWSScout2/rules/data/findings/s3-bucket-world-policy-star.json
+++ b/AWSScout2/rules/data/findings/s3-bucket-world-policy-star.json
@@ -8,7 +8,13 @@
         [ "s3.buckets.id.", "withKey", "policy" ],
         [ "s3.buckets.id.policy.Statement.id.Effect", "equal", "Allow" ],
         [ "s3.buckets.id.policy.Statement.id.", "withoutKey", "Condition" ],
-        [ "s3.buckets.id.policy.Statement.id.Principal", "containAtLeastOneOf", [ "*" ] ],
-        [ "s3.buckets.id.policy.Statement.id.Action", "containAtLeastOneOf", [ "s3:*", "*" ] ]
+        [ "s3.buckets.id.policy.Statement.id.Action", "containAtLeastOneOf", [ "s3:*", "*" ] ],
+        [ "or",
+          [ "s3.buckets.id.policy.Statement.id.Principal", "containAtLeastOneOf", [ "*" ] ],
+          [ "and",
+            [ "s3.buckets.id.policy.Statement.id.Principal", "withKey", "AWS" ],
+            [ "s3.buckets.id.policy.Statement.id.Principal.AWS", "containAtLeastOneOf", [ "*" ] ]
+          ]
+        ]
     ]
 }


### PR DESCRIPTION
In an S3 bucket policy, the principal can be specified in one of two formats:

1. "Principal": "*"
2. "Principal": {"AWS": "*"}

This adds support for the second format.