### PR TITLE
Fix IOError opening aws-in-us.json

### DIFF
--- a/AWSScout2/rules/data/findings/ec2-security-group-whitelists-aws-ip-from-banned-region.json
+++ b/AWSScout2/rules/data/findings/ec2-security-group-whitelists-aws-ip-from-banned-region.json
@@ -4,6 +4,6 @@
     "dashboard_name": "Rules",
     "conditions": [ "and",
         [ "this", "inSubnets", "_IP_RANGES_FROM_FILE_(ip-ranges/aws.json, [])" ],
-        [ "this", "notInSubnets", "_IP_RANGES_FROM_LOCAL_FILE_(AWSScout2/rules/data/ip-ranges/aws-in-us.json, [])" ]
+        [ "this", "notInSubnets", "_IP_RANGES_FROM_FILE_(ip-ranges/aws-in-us.json, [])" ]
     ]
 }


### PR DESCRIPTION
I'm getting:

    IOError: [Errno 2] No such file or directory: u'/root/AWSScout2/rules/data/ip-ranges/aws-in-us.json' 

This change seems to fix it for me.